### PR TITLE
MCA Villager Child Making Limited

### DIFF
--- a/base/config/MCA.cfg
+++ b/base/config/MCA.cfg
@@ -62,7 +62,7 @@ general {
     I:"Story progression rate"=20
 
     # Determines whether or not story progression will occur based on this number of villagers within a 32 block radius. Set to -1 to disable. 16 is recommended.
-    I:"Story progression spawn cap"=-1
+    I:"Story progression spawn cap"=100
 
     # Amount of time a villager has to be alive before story progression begins to affect them. This value is in MINUTES, default is 120. Range (1 and above)
     I:"Story progression threshold"=120


### PR DESCRIPTION
Limited Villager fornification to 100 villagers in a 32m radius, they wont multiply any more once they hit that density in a 32m area (tollana will be safe again)
this can be lowered further if 100 still proves too much