### PR TITLE
Maximum Ship Mass to 5000

### DIFF
--- a/base/config/WarpDrive/WarpDrive.cfg
+++ b/base/config/WarpDrive/WarpDrive.cfg
@@ -811,7 +811,7 @@ ship {
     I:teleport_energy_per_entity=1000000
 
     # Maximum ship mass (in blocks) to jump on a planet
-    I:volume_max_on_planet_surface=3000
+    I:volume_max_on_planet_surface=5000
 
     # Minimum ship mass (in blocks) to enter or exit hyperspace without a jumpgate
     I:volume_min_for_hyperspace=1200


### PR DESCRIPTION
Increases maximum ship masss for WarpDrive by 66%
