### PR TITLE
Skystone Meteor update

### DIFF
--- a/base/config/AppliedEnergistics2/AppliedEnergistics2.cfg
+++ b/base/config/AppliedEnergistics2/AppliedEnergistics2.cfg
@@ -404,9 +404,7 @@ wireless {
 worldgen {
     D:meteoriteClusterChance=0.1
     I:meteoriteDimensionWhitelist <
-		-411
-		-332
-		-393
+		-65
      >
     D:meteoriteSpawnChance=0.1
     D:metoriteClusterChance=0.1


### PR DESCRIPTION
should fix AE2 Meteors spawning in worlds